### PR TITLE
Fix `encodeTrim*` on special strings with repeat tokens

### DIFF
--- a/tokenizer_ts/package-lock.json
+++ b/tokenizer_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/tiktokenizer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/tiktokenizer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "lru-cache": "^9.1.1"
@@ -2061,9 +2061,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"

--- a/tokenizer_ts/package.json
+++ b/tokenizer_ts/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/tiktokenizer",
   "displayName": "tiktokenizer",
   "description": "Tokenizer for OpenAI large language models.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/tokenizer_ts/test/tikTokenizer.test.ts
+++ b/tokenizer_ts/test/tikTokenizer.test.ts
@@ -196,7 +196,6 @@ suite("TikTokenizer Test Suite", function() {
     ]);
     assert.deepStrictEqual(encoded.text, str);
 
-    const testEncode = tokenizer.encode(str, Array.from(specialTokens.keys()));
     encoded = tokenizer.encodeTrimPrefix(
       str,
       3,

--- a/tokenizer_ts/test/tikTokenizer.test.ts
+++ b/tokenizer_ts/test/tikTokenizer.test.ts
@@ -91,7 +91,7 @@ suite("TikTokenizer Test Suite", function() {
 
   test("encode trim suffix - 2", () => {
     const str = "<|im_start|>Hello TempWorld<|im_end|>";
-    const encodedStr = "<|im_start|>Hello";
+    const encodedStr = "<|im_start|>Hello TempWorld";
     let encoded = tokenizer.encodeTrimSuffix(
       str,
       5,
@@ -125,8 +125,16 @@ suite("TikTokenizer Test Suite", function() {
       3,
       Array.from(specialTokens.keys())
     );
-    assert.deepStrictEqual(encoded.tokenIds, [100264, 9906]);
+    assert.deepStrictEqual(encoded.tokenIds, [100264, 9906, 20539]);
     assert.deepStrictEqual(encoded.text, encodedStr);
+  });
+
+  test("encode trim suffix - 3", () => {
+    const str = "t".repeat(4000);
+    const encodedStr = tokenizer.encode(str);
+    let encodedTrimSuffix = tokenizer.encodeTrimSuffix(str, 5, []);
+    assert.deepStrictEqual(encodedTrimSuffix.tokenIds.length, 5);
+    assert.deepStrictEqual(encodedTrimSuffix.tokenIds, encodedStr.slice(0, 5));
   });
 
   test("encode trim prefix", () => {
@@ -188,6 +196,7 @@ suite("TikTokenizer Test Suite", function() {
     ]);
     assert.deepStrictEqual(encoded.text, str);
 
+    const testEncode = tokenizer.encode(str, Array.from(specialTokens.keys()));
     encoded = tokenizer.encodeTrimPrefix(
       str,
       3,
@@ -195,6 +204,14 @@ suite("TikTokenizer Test Suite", function() {
     );
     assert.deepStrictEqual(encoded.tokenIds, [4435, 100265]);
     assert.deepStrictEqual(encoded.text, encodedStr);
+  });
+
+  test("encode trim prefix - 3", () => {
+    const str = "t".repeat(4000);
+    const encodedStr = tokenizer.encode(str);
+    let encodedTrimSuffix = tokenizer.encodeTrimPrefix(str, 5, []);
+    assert.deepStrictEqual(encodedTrimSuffix.tokenIds.length, 5);
+    assert.deepStrictEqual(encodedTrimSuffix.tokenIds, encodedStr.slice(encodedStr.length - 5));
   });
 
   test("tokenize source code - gpt-3.5", done => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/Tokenizer/issues/25


This one was a bit challenging, it appears that there are cases where the match is continuous in such a way that you cannot encode it in chunks and instead must encode the entire thing.


It does make me wonder why we don't just have these functions be the naive implementation calling "encode" and "decode" or leaving it up to the consumer to implement. The normal TikToken library does not have these functions making it difficult to have something to reference as a base.