### PR TITLE
Use `exec` for regex matching

### DIFF
--- a/tokenizer_ts/src/tikTokenizer.ts
+++ b/tokenizer_ts/src/tikTokenizer.ts
@@ -196,15 +196,10 @@ export class TikTokenizer {
     start: number,
     end: number
   ): void {
-    let match: RegExpMatchArray | null | undefined;
-    const matches = Array.from(
-      text.substring(start, end).matchAll(this.regex!)
-    );
-    for (var i = 0; i < matches.length; i++) {
-      match = matches[i];
-      if (match === undefined) {
-        break;
-      }
+    let match: RegExpExecArray | null;
+    const substring = text.substring(start, end);
+    this.regex!.lastIndex = 0;
+    while ((match = this.regex!.exec(substring))) {
       if (this.cache.has(match[0])) {
         tokenIds.push(...this.cache.get(match[0])!);
       } else {
@@ -232,12 +227,10 @@ export class TikTokenizer {
     tokenCount: number,
     encodeLength: number
   ): { tokenCount: number; encodeLength: number } {
-    let match: RegExpMatchArray | null | undefined;
-    const matches = Array.from(
-      text.substring(start, end).matchAll(this.regex!)
-    );
-    for (var i = 0; i < matches.length; i++) {
-      match = matches[i];
+    let match: RegExpExecArray | null;
+    const substring = text.substring(start, end);
+    this.regex!.lastIndex = 0;
+    while ((match = this.regex!.exec(substring))) {
       const piece = match[0];
       if (this.cache.has(piece)) {
         let tokens = this.cache.get(piece);
@@ -388,12 +381,10 @@ export class TikTokenizer {
       );
 
       if (end > start) {
-        let match: RegExpMatchArray | null | undefined;
-        const matches = Array.from(
-          text.substring(start, end).matchAll(this.regex!)
-        );
-        for (var i = 0; i < matches.length; i++) {
-          match = matches[i];
+        let match: RegExpExecArray | null;
+        const substring = text.substring(start, end);
+        this.regex!.lastIndex = 0;
+        while ((match = this.regex!.exec(substring))) {
           const piece = match[0];
 
           if (this.cache.has(piece)) {


### PR DESCRIPTION
Small optimization switching to use `exec` instead of `matchAll`. This is around 50% after in v8 and 70% faster in safari. This is also 20% faster than using `for of` over `matchAll` directly to avoid generating extra arrays