### PR TITLE
Speed up `uint8ArrayToString`

### DIFF
--- a/tokenizer_ts/src/bytePairEncode.ts
+++ b/tokenizer_ts/src/bytePairEncode.ts
@@ -7,9 +7,7 @@
  * @returns string
  */
 export function uint8ArrayToString(uint8Array: Uint8Array): string {
-  return Array.from(uint8Array)
-    .map(num => num.toString())
-    .join("_");
+  return uint8Array.toString();
 }
 
 /**


### PR DESCRIPTION
Uses the native `Uint8Array.toString` implementation. Seems silly but it actually is pretty fast. In my artificial benchmarking testing 1000 random arrays of between length 1 and 10, this is 70% faster

I also testing a change which avoids converting to a string using something like:

```js
function uint8ArrayToString(uint8Array): any {
  if (uint8Array.length <= 3) {
    return (uint8Array[0] << 16 | uint8Array[1] << 8 | uint8Array[2] | uint8Array[3] << 24);
  }

  let hash = BigInt(0);
  for (let i = 0; i < uint8Array.length; i++) {
    hash |= BigInt(uint8Array[i]) << BigInt(8 * i);
  }
  return hash;
} 
```

But it wasn't actually any faster

