### PR TITLE
Small optimizations

### DIFF
--- a/tokenizer_ts/src/bytePairEncode.ts
+++ b/tokenizer_ts/src/bytePairEncode.ts
@@ -26,16 +26,16 @@ export function bytePairEncode(
     return [ranks.get(mergingBytes[0].toString())!];
   }
 
-  const byteIndicesAndRanks: [number, number][] = [];
+  const byteIndicesAndRanks = new Array<{ index: number; rank: number }>(mergingBytes.length + 1);
   for (let i = 0; i < mergingBytes.length + 1; i++) {
-    byteIndicesAndRanks.push([i, Number.MAX_SAFE_INTEGER]);
+    byteIndicesAndRanks[i] = { index: i, rank: Number.MAX_SAFE_INTEGER };
   }
 
   function getRank(startIndex: number, skip = 0): number {
     if (startIndex + skip + 2 < byteIndicesAndRanks.length) {
-      const slice = mergingBytes.slice(
-        byteIndicesAndRanks[startIndex][0],
-        byteIndicesAndRanks[startIndex + skip + 2][0]
+      const slice = mergingBytes.subarray(
+        byteIndicesAndRanks[startIndex].index,
+        byteIndicesAndRanks[startIndex + skip + 2].index
       );
       const rank = ranks.get(uint8ArrayToString(slice));
       if (rank !== undefined) {
@@ -48,22 +48,22 @@ export function bytePairEncode(
   for (let i = 0; i < byteIndicesAndRanks.length - 2; i++) {
     const rank = getRank(i);
     if (rank !== Number.MAX_SAFE_INTEGER) {
-      byteIndicesAndRanks[i][1] = rank;
+      byteIndicesAndRanks[i].rank = rank;
     }
   }
 
   while (byteIndicesAndRanks.length > 1) {
     let minRank: [number, number] = [0, Number.MAX_SAFE_INTEGER];
     for (let i = 0; i < byteIndicesAndRanks.length - 1; i++) {
-      if (byteIndicesAndRanks[i][1] < minRank[1]) {
-        minRank = [i, byteIndicesAndRanks[i][1]];
+      if (byteIndicesAndRanks[i].rank < minRank[1]) {
+        minRank = [i, byteIndicesAndRanks[i].rank];
       }
     }
     if (minRank[1] !== Number.MAX_SAFE_INTEGER) {
       const j = minRank[0];
-      byteIndicesAndRanks[j][1] = getRank(j, 1);
+      byteIndicesAndRanks[j].rank = getRank(j, 1);
       if (j > 0) {
-        byteIndicesAndRanks[j - 1][1] = getRank(j - 1, 1);
+        byteIndicesAndRanks[j - 1].rank = getRank(j - 1, 1);
       }
       byteIndicesAndRanks.splice(j + 1, 1);
     } else {
@@ -71,18 +71,16 @@ export function bytePairEncode(
     }
   }
 
-  const outList: number[] = [];
+  const outList = new Array<number>(byteIndicesAndRanks.length - 1);
   for (let i = 0; i < byteIndicesAndRanks.length - 1; i++) {
-    outList.push(
-      ranks.get(
-        uint8ArrayToString(
-          mergingBytes.slice(
-            byteIndicesAndRanks[i][0],
-            byteIndicesAndRanks[i + 1][0]
-          )
+    outList[i] = ranks.get(
+      uint8ArrayToString(
+        mergingBytes.subarray(
+          byteIndicesAndRanks[i].index,
+          byteIndicesAndRanks[i + 1].index
         )
-      )!
-    );
+      )
+    )!;
   }
   return outList;
 }


### PR DESCRIPTION
Quick pass making a few small optimizations:

- Replace `has` + `get` with a single `get` call
- Reuse `this.textEncoder`
- Use `subarray` instead of `slice` to avoid copying the `UInt8Array`
- Create an array of objects instead of tuples. This can be significantly faster (and is also more readable imo)
- Create presized arrays in `bytePairEncode`