### PR TITLE
perf: reduce allocations when encoding text

### DIFF
--- a/tokenizer_ts/perf/notebook.ipynb
+++ b/tokenizer_ts/perf/notebook.ipynb
@@ -11,20 +11,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": 1,
+   "metadata": {
+    "metadata": {}
+   },
+   "outputs": [],
    "source": [
     "import os\n",
     "import subprocess\n",
@@ -40,7 +31,7 @@
     "    parsed = json.loads(result)\n",
     "    return parsed\n",
     "\n",
-    "os.system('npm install @microsoft/tiktokenizer --prefix ./')\n"
+    "#os.system('npm install @microsoft/tiktokenizer --prefix ./')\n"
    ]
   },
   {
@@ -52,8 +43,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "metadata": {}
+   },
    "outputs": [],
    "source": [
     "# This can take a minute, make some tea 🍵\n",
@@ -62,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -97,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -133,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/tokenizer_ts/src/bytePairEncode.ts
+++ b/tokenizer_ts/src/bytePairEncode.ts
@@ -87,9 +87,10 @@ const maxRank = 0x7FFFFFFF; // max int32, try and keep things in integer space
  */
 export function bytePairEncode(
   mergingBytes: Uint8Array,
-  ranks: BinaryMap<number>
+  ranks: BinaryMap<number>,
+  length: number,
 ): number[] {
-  if (mergingBytes.length === 1) {
+  if (length === 1) {
     return [ranks.get(mergingBytes)!];
   }
 
@@ -97,7 +98,7 @@ export function bytePairEncode(
   let minIndex = -1;
 
   const byteIndicesAndRanks: [number, number][] = [];
-  for (let i = 0; i < mergingBytes.length - 1; i++) {
+  for (let i = 0; i < length - 1; i++) {
     const rank = ranks.get(mergingBytes, i, i + 2) ?? maxRank;
     if (rank < minRank) {
       minRank = rank;
@@ -106,8 +107,8 @@ export function bytePairEncode(
 
     byteIndicesAndRanks.push([i, rank]);
   }
-  byteIndicesAndRanks.push([mergingBytes.length - 1, maxRank]);
-  byteIndicesAndRanks.push([mergingBytes.length, maxRank]);
+  byteIndicesAndRanks.push([length - 1, maxRank]);
+  byteIndicesAndRanks.push([length, maxRank]);
 
   function getRank(startIndex: number, skip = 0): number {
     if (startIndex + skip + 2 < byteIndicesAndRanks.length) {

--- a/tokenizer_ts/src/textEncoder.ts
+++ b/tokenizer_ts/src/textEncoder.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * A text encoder interface.
+ */
+export interface ITextEncoder {
+  /**
+   * Number of bytes written in the last call to {@link encode}
+   */
+  length: number;
+
+  /**
+   * Encodes the text and returns the Uint8Array it was written to. The length
+   * of data written to the array can be found in {@link length}.
+   *
+   * The data returned in the array is only valid until the next call to encode.
+   */
+  encode(text: string): Uint8Array;
+}
+
+class UniversalTextEncoder implements ITextEncoder {
+  public length = 0;
+  private encoder = new TextEncoder();
+
+  public encode(text: string): Uint8Array {
+    const arr = this.encoder.encode(text);
+    this.length = arr.length;
+    return arr;
+  }
+}
+
+class NodeTextEncoder implements ITextEncoder {
+  private buffer = Buffer.alloc(256);
+  public length = 0;
+
+  public encode(text: string): Uint8Array {
+    while (true) {
+      this.length = this.buffer.write(text, 'utf8');
+
+      // buffer.write returns the number of bytes written and can write less
+      // than the length of the string if the buffer is too small. If this
+      // might have happened (4 bytes is the longest utf8 codepoint), make
+      // the buffer bigger and try again.
+      if (this.length < this.buffer.length - 4) {
+        return this.buffer;
+      }
+
+      this.buffer = Buffer.alloc(this.length * 2);
+      this.length = this.buffer.write(text);
+    }
+  }
+}
+
+export const makeTextEncoder = (): ITextEncoder =>
+  typeof Buffer !== 'undefined' ? new NodeTextEncoder() : new UniversalTextEncoder();


### PR DESCRIPTION
The tokenizer encodes each substring after regex splitting. Allocating
an entirely new array for each substring is wasteful. Instead, because
each encoded string is only used internally, we can reuse the same
buffer in Node.js environments.

This reduces tokenization time by about 13%:

![](https://memes.peet.io/img/24-04-7e16113b-f7bd-41d1-85bb-dad1a7b6b9c6.png)

Builds on https://github.com/microsoft/Tokenizer/pull/35, only the last commit is new. Closes #38