### PR TITLE
Add token counting tokens to ITokenizer and TikTokenizer

### DIFF
--- a/Tokenizer_C#/TokenizerLib/ITokenizer.cs
+++ b/Tokenizer_C#/TokenizerLib/ITokenizer.cs
@@ -43,5 +43,15 @@ namespace Microsoft.DeepDev
         /// Decode an array of integer token ids
         /// </summary>
         public string Decode(int[] tokens);
+
+        /// <summary>
+        /// Count a string with or without special tokens set through constructor.
+        /// </summary>
+        public int Count(string text, bool applySpecialTokens = true, int max = int.MaxValue);
+
+        /// <summary>
+        /// Count a string with a set of allowed special tokens that are not broken apart.
+        /// </summary>
+        public int Count(string text, IReadOnlyCollection<string> allowedSpecial, int max = int.MaxValue); 
     }
 }

--- a/Tokenizer_C#/TokenizerTest/TikTokenizerUnitTest.cs
+++ b/Tokenizer_C#/TokenizerTest/TikTokenizerUnitTest.cs
@@ -304,5 +304,27 @@ namespace TokenizerTest
             Assert.AreEqual(text, decoded);
         }
 
+        [TestMethod]
+        public void TestCountR50kbbase()
+        {
+            var text = File.ReadAllText("./testData/lib.rs.txt");
+            var count = Tokenizer_r50k_base.Count(text, new HashSet<string>());
+            Assert.AreEqual(11378, count);
+        }
+
+        [TestMethod]
+        public void TestCountR50kbbaseSetMaxTokens()
+        {
+            var text = File.ReadAllText("./testData/lib.rs.txt");
+            var count = Tokenizer_r50k_base.Count(text, new HashSet<string>(), 10000);
+            Assert.AreEqual(10000, count);
+        }
+
+        [TestMethod]
+        public void TestCount0Tokens()
+        {
+            var count = Tokenizer_r50k_base.Count("", new HashSet<string>());
+            Assert.AreEqual(0, count);
+        }
     }
 }


### PR DESCRIPTION
Updated the ITokenizer interface to include two new methods for counting tokens in a string, with options for handling special tokens. Implemented these methods in the TikTokenizer class, adding logic for counting based on special tokens and a maximum limit. Added unit tests in TokenizerTest to verify the new counting functionality, including cases for special tokens and empty strings. In case of checking length the allocation of the list is not done. When using the max count value, the method stops counting when the maxinum number of tokens is exceeded. This prevents endless counting when extreemly large content is provided.