### PR TITLE
feat: use require to load fs and path modules for browser compatibility

### DIFF
--- a/tokenizer_ts/package-lock.json
+++ b/tokenizer_ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/tiktokenizer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/tiktokenizer",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^5.2.7",

--- a/tokenizer_ts/package.json
+++ b/tokenizer_ts/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/tiktokenizer",
   "displayName": "tiktokenizer",
   "description": "Tokenizer for OpenAI large language models.",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/tokenizer_ts/src/tikTokenizer.ts
+++ b/tokenizer_ts/src/tikTokenizer.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as fs from "fs";
-import { TextDecoder } from "util";
 import { BinaryMap, bytePairEncode } from "./bytePairEncode";
 import { makeTextEncoder } from './textEncoder';
 import { ILRUCache, LRUCache } from './lru';
@@ -15,6 +13,7 @@ import { ILRUCache, LRUCache } from './lru';
 function loadTikTokenBpe(tikTokenBpeFile: string): Map<Uint8Array, number> {
   const bpeDict = new Map<Uint8Array, number>();
   try {
+    const fs = require("fs"); // Defer loading the node fs module for browser compatibility
     const fileContent = fs.readFileSync(tikTokenBpeFile, "utf-8");
     processBpeRanks(fileContent);
     return bpeDict;

--- a/tokenizer_ts/src/tokenizerBuilder.ts
+++ b/tokenizer_ts/src/tokenizerBuilder.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as fs from "fs";
-import * as path from "path";
 import { TikTokenizer } from "./tikTokenizer";
 
 const MODEL_PREFIX_TO_ENCODING: ReadonlyMap<string, string> = new Map([
@@ -109,6 +107,7 @@ async function fetchAndSaveFile(
   mergeableRanksFileUrl: string,
   filePath: string
 ): Promise<void> {
+  const fs = require("fs"); // Defer loading the node fs module for browser compatibility
   const response = await fetch(mergeableRanksFileUrl);
 
   if (!response.ok) {
@@ -267,6 +266,9 @@ export async function createByEncoderName(
     specialTokens = new Map([...specialTokens, ...extraSpecialTokens]);
   }
 
+  // Defer loading the node fs and path modules for browser compatibility
+  const fs = require("fs");
+  const path = require("path");
   const fileName = path.basename(mergeableRanksFileUrl);
   const dirPath = path.resolve(__dirname, "..", "model");
   // Create the directory if it doesn't exist


### PR DESCRIPTION
Deferring the `require` calls to load the Node.js `fs` and `path` modules is all that is needed to enable web compatible if the the tokenizer file contents are loaded through other means and supplied to the library.

Based on a similar approach taken by [web-tree-sitter](https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_web/README.md#cant-resolve-fs-in-node_modulesweb-tree-sitter).

Fixes https://github.com/microsoft/Tokenizer/issues/45