### PR TITLE
Bump actions dependencies to v4

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://npm.pkg.github.com'
@@ -25,7 +25,7 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: npm-package
           path: tokenizer_ts/*.tgz

--- a/.github/workflows/tokenizer-ts-pr-build.yml
+++ b/.github/workflows/tokenizer-ts-pr-build.yml
@@ -11,8 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://npm.pkg.github.com'
@@ -24,7 +24,7 @@ jobs:
       - run: npm pack
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: npm-package
           path: tokenizer_ts/*.tgz

--- a/.github/workflows/tokenizer-ts-release.yml
+++ b/.github/workflows/tokenizer-ts-release.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
@@ -25,7 +25,7 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: npm-package
           path: tokenizer_ts/*.tgz


### PR DESCRIPTION
Required for actions/upload-artifact or actions/download-artifact.

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
Example failure: https://github.com/microsoft/Tokenizer/actions/runs/14670713096